### PR TITLE
Remove flavor setting.

### DIFF
--- a/libs.autobuild
+++ b/libs.autobuild
@@ -1,9 +1,7 @@
-in_flavor 'stable' do
-    bundle_package 'bundles/tutorials'
-    bundle_package 'bundles/tutorials_scripts'
-    cmake_package 'tutorials/rock_tutorial'
-    cmake_package 'tutorials/vizkit3d_plugin_tutorial'
-    cmake_package 'tutorials/message_driver'
-    cmake_package 'tutorials/designer_widget_tutorial'
-end
+bundle_package 'bundles/tutorials'
+bundle_package 'bundles/tutorials_scripts'
+cmake_package 'tutorials/rock_tutorial'
+cmake_package 'tutorials/vizkit3d_plugin_tutorial'
+cmake_package 'tutorials/message_driver'
+cmake_package 'tutorials/designer_widget_tutorial'
 

--- a/orogen.autobuild
+++ b/orogen.autobuild
@@ -1,9 +1,7 @@
-in_flavor 'stable' do
-    orogen_package 'tutorials/orogen/tut_follower'
-    orogen_package 'tutorials/orogen/tut_brownian'
-    orogen_package 'tutorials/orogen/tut_deployment'
-    orogen_package 'tutorials/orogen/rock_tutorial'
-    orogen_package 'tutorials/orogen/tut_sensor'
-    orogen_package 'tutorials/orogen/message_producer'
-    orogen_package 'tutorials/orogen/message_consumer'
-end
+orogen_package 'tutorials/orogen/tut_follower'
+orogen_package 'tutorials/orogen/tut_brownian'
+orogen_package 'tutorials/orogen/tut_deployment'
+orogen_package 'tutorials/orogen/rock_tutorial'
+orogen_package 'tutorials/orogen/tut_sensor'
+orogen_package 'tutorials/orogen/message_producer'
+orogen_package 'tutorials/orogen/message_consumer'


### PR DESCRIPTION
This flavor setting causes that if the metapackage

rock.tutorials was added to the manifest the tutorals are not build.

Don't know if this is a bug from the flavor/autoproj handling or intend, but it makes no sense here.

<b>If you agree i will push also to the rock-rc branch.</b>
